### PR TITLE
Add token introspection endpoint

### DIFF
--- a/auth/service.go
+++ b/auth/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 
+	"github.com/golang-jwt/jwt/v4"
 	"github.com/ninth-realm/heimdall/crypto"
 	"github.com/ninth-realm/heimdall/store"
 )
@@ -32,10 +33,25 @@ func (s Service) Login(ctx context.Context, username, password string) (Token, e
 		return Token{}, errors.New("incorrect password")
 	}
 
-	token, err := generateJWT(s.JWTSettings)
+	token, err := generateJWT(user, s.JWTSettings)
 	if err != nil {
 		return Token{}, err
 	}
 
 	return token, nil
+}
+
+func (s Service) IntrospectToken(ctx context.Context, token string) (TokenInfo, error) {
+	t, err := validateJWT(token, s.JWTSettings)
+	if err != nil {
+		return TokenInfo{}, err
+	}
+
+	claims := t.Claims.(jwt.MapClaims)
+
+	return TokenInfo{
+		Active:    true,
+		ExpiresAt: int(claims["exp"].(float64)),
+		UserID:    claims["sub"].(string),
+	}, nil
 }

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -2,6 +2,9 @@ package auth
 
 import (
 	"testing"
+
+	"github.com/gofrs/uuid/v5"
+	"github.com/ninth-realm/heimdall/store"
 )
 
 func TestJWTSettings_validate(t *testing.T) {
@@ -81,12 +84,16 @@ func TestJWTSettings_validate(t *testing.T) {
 func Test_generateJWT(t *testing.T) {
 	tests := []struct {
 		name     string
+		user     store.User
 		settings JWTSettings
 		want     Token
 		wantErr  bool
 	}{
 		{
 			name: "Success",
+			user: store.User{
+				ID: uuid.Nil,
+			},
 			settings: JWTSettings{
 				Issuer:     "Heimdall",
 				Lifespan:   60,
@@ -99,7 +106,10 @@ func Test_generateJWT(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name:     "Invalid settings returns error",
+			name: "Invalid settings returns error",
+			user: store.User{
+				ID: uuid.Nil,
+			},
 			settings: JWTSettings{},
 			want:     Token{},
 			wantErr:  true,
@@ -107,7 +117,7 @@ func Test_generateJWT(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := generateJWT(tt.settings)
+			got, err := generateJWT(tt.user, tt.settings)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("generateJWT() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/http/routes.go
+++ b/http/routes.go
@@ -17,4 +17,5 @@ func (s *Server) loadRoutes() {
 	s.Router.Delete("/api/v1/clients/{clientID}/api-keys/{keyID}", s.handleClientsAPIKeysDelete())
 
 	s.Router.Post("/api/v1/auth/login", s.handleAuthLogin())
+	s.Router.Post("/api/v1/auth/introspect", s.handleAuthIntrospect())
 }

--- a/http/server.go
+++ b/http/server.go
@@ -47,6 +47,7 @@ type ClientService interface {
 
 type AuthService interface {
 	Login(ctx context.Context, username, password string) (auth.Token, error)
+	IntrospectToken(ctx context.Context, token string) (auth.TokenInfo, error)
 }
 
 // NewServer builds a new server object with the default middleware and router


### PR DESCRIPTION
## Summary

This PR introduces the token introspection endpoint. The purpose of this is to provide clients a method for validating user access tokens. This endpoint will have to be protected to only allow authorized clients to access it, but this will be added later.

## Testing

1. Ensure you have a user created.
2. Apply the following patch to allow tokens to quickly expire
```diff
diff --git a/cmd/heimdall/main.go b/cmd/heimdall/main.go
index a9b9128..41da3b4 100644
--- a/cmd/heimdall/main.go
+++ b/cmd/heimdall/main.go
@@ -89,7 +89,7 @@ func buildServer(db store.Repository) *http.Server {
                Repo: db,
                JWTSettings: auth.JWTSettings{
                        Issuer:     "heimdall",
-                       Lifespan:   900,
+                       Lifespan:   30,
                        SigningKey: "so-secret-wow",
                        Algorithm:  auth.HMAC256Algorithm,
                },
```
3. Login with the following:
```sh
$ curl -X POST \
-d '{"username":"<USER'S EMAIL>", "password":"<USER'S PASSWORD>"}' \
'http://localhost:8080/api/v1/auth/login'
```
4. Take the access token and ensure the following request succeeds.
```sh
$ curl -X POST \
-d '{"token":"<TOKEN>"}' \
'http://localhost:8080/api/v1/auth/introspect'
```
5. Wait a bit and rerun the request. It should return a 401.