### PR TITLE
Add authentication middleware

### DIFF
--- a/http/auth.go
+++ b/http/auth.go
@@ -1,0 +1,49 @@
+package http
+
+import (
+	"errors"
+	"net/http"
+)
+
+const APIKeyHeaderName = "X-API-Key"
+
+const SessionCookieName = "heimdall_sessionToken"
+
+var authErr = errors.New("missing or invalid auth token")
+
+func (s *Server) authenticateRoute(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		err := s.authenticateAPIKey(r)
+		if err == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		err = s.authenticateSessionToken(r)
+		if err == nil {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		s.respondWithError(w, r, http.StatusUnauthorized, authErr)
+	})
+}
+
+func (s *Server) authenticateAPIKey(r *http.Request) error {
+	token := r.Header.Get(APIKeyHeaderName)
+	if token == "" {
+		return authErr
+	}
+
+	return s.AuthService.ValidateAPIKey(r.Context(), token)
+}
+
+func (s *Server) authenticateSessionToken(r *http.Request) error {
+	cookie, err := r.Cookie(SessionCookieName)
+	if err != nil || cookie.Value == "" {
+		return authErr
+	}
+
+	_, err = s.AuthService.IntrospectToken(r.Context(), cookie.Value)
+	return err
+}

--- a/http/auth_handlers.go
+++ b/http/auth_handlers.go
@@ -32,7 +32,7 @@ func (s *Server) handleAuthLogin() http.HandlerFunc {
 		}
 
 		http.SetCookie(w, &http.Cookie{
-			Name:     "session",
+			Name:     SessionCookieName,
 			Value:    token.AccessToken,
 			Path:     "/",
 			Secure:   true,

--- a/http/routes.go
+++ b/http/routes.go
@@ -1,21 +1,21 @@
 package http
 
 func (s *Server) loadRoutes() {
-	s.Router.Get("/api/v1/users", s.handleUsersList())
-	s.Router.Post("/api/v1/users", s.handleUsersCreate())
-	s.Router.Get("/api/v1/users/{userID}", s.handleUsersGet())
-	s.Router.Patch("/api/v1/users/{userID}", s.handleUsersUpdate())
-	s.Router.Delete("/api/v1/users/{userID}", s.handleUsersDelete())
+	s.Router.With(s.authenticateRoute).Get("/api/v1/users", s.handleUsersList())
+	s.Router.With(s.authenticateRoute).Post("/api/v1/users", s.handleUsersCreate())
+	s.Router.With(s.authenticateRoute).Get("/api/v1/users/{userID}", s.handleUsersGet())
+	s.Router.With(s.authenticateRoute).Patch("/api/v1/users/{userID}", s.handleUsersUpdate())
+	s.Router.With(s.authenticateRoute).Delete("/api/v1/users/{userID}", s.handleUsersDelete())
 
-	s.Router.Get("/api/v1/clients", s.handleClientsList())
-	s.Router.Post("/api/v1/clients", s.handleClientsCreate())
-	s.Router.Get("/api/v1/clients/{clientID}", s.handleClientsGet())
-	s.Router.Patch("/api/v1/clients/{clientID}", s.handleClientsUpdate())
-	s.Router.Delete("/api/v1/clients/{clientID}", s.handleClientsDelete())
-	s.Router.Get("/api/v1/clients/{clientID}/api-keys", s.handleClientsAPIKeysGet())
-	s.Router.Post("/api/v1/clients/{clientID}/api-keys", s.handleClientsAPIKeysCreate())
-	s.Router.Delete("/api/v1/clients/{clientID}/api-keys/{keyID}", s.handleClientsAPIKeysDelete())
+	s.Router.With(s.authenticateRoute).Get("/api/v1/clients", s.handleClientsList())
+	s.Router.With(s.authenticateRoute).Post("/api/v1/clients", s.handleClientsCreate())
+	s.Router.With(s.authenticateRoute).Get("/api/v1/clients/{clientID}", s.handleClientsGet())
+	s.Router.With(s.authenticateRoute).Patch("/api/v1/clients/{clientID}", s.handleClientsUpdate())
+	s.Router.With(s.authenticateRoute).Delete("/api/v1/clients/{clientID}", s.handleClientsDelete())
+	s.Router.With(s.authenticateRoute).Get("/api/v1/clients/{clientID}/api-keys", s.handleClientsAPIKeysGet())
+	s.Router.With(s.authenticateRoute).Post("/api/v1/clients/{clientID}/api-keys", s.handleClientsAPIKeysCreate())
+	s.Router.With(s.authenticateRoute).Delete("/api/v1/clients/{clientID}/api-keys/{keyID}", s.handleClientsAPIKeysDelete())
 
 	s.Router.Post("/api/v1/auth/login", s.handleAuthLogin())
-	s.Router.Post("/api/v1/auth/introspect", s.handleAuthIntrospect())
+	s.Router.With(s.authenticateRoute).Post("/api/v1/auth/introspect", s.handleAuthIntrospect())
 }

--- a/http/server.go
+++ b/http/server.go
@@ -48,6 +48,7 @@ type ClientService interface {
 type AuthService interface {
 	Login(ctx context.Context, username, password string) (auth.Token, error)
 	IntrospectToken(ctx context.Context, token string) (auth.TokenInfo, error)
+	ValidateAPIKey(ctx context.Context, key string) error
 }
 
 // NewServer builds a new server object with the default middleware and router

--- a/store/client.go
+++ b/store/client.go
@@ -61,6 +61,7 @@ type ClientRepository interface {
 	SaveClient(user Client, opts QueryOptions) error
 	DeleteClient(id uuid.UUID, opts QueryOptions) error
 
+	GetClientAPIKey(clientID uuid.UUID, prefix string, opts QueryOptions) (APIKey, error)
 	ListClientAPIKeys(clientID uuid.UUID, opts QueryOptions) ([]APIKey, error)
 	InsertAPIKey(key NewAPIKey, opts QueryOptions) (uuid.UUID, error)
 	DeleteClientAPIKey(clientID, keyID uuid.UUID, opts QueryOptions) error

--- a/store/sqlite/client.go
+++ b/store/sqlite/client.go
@@ -123,6 +123,32 @@ func (db DB) DeleteClient(id uuid.UUID, opts store.QueryOptions) error {
 
 }
 
+func (db DB) GetClientAPIKey(clientID uuid.UUID, prefix string, opts store.QueryOptions) (store.APIKey, error) {
+	const query = `
+		SELECT
+			id,
+			client_id,
+			description,
+			prefix,
+			hash,
+			created_at,
+			updated_at
+		FROM
+			api_key
+		WHERE
+			client_id = ?
+			AND prefix = ?
+	`
+
+	var key store.APIKey
+	err := db.querier(opts.Txn).GetContext(opts.Context(), &key, query, clientID, prefix)
+	if err != nil {
+		return store.APIKey{}, err
+	}
+
+	return key, nil
+}
+
 func (db DB) ListClientAPIKeys(clientID uuid.UUID, opts store.QueryOptions) ([]store.APIKey, error) {
 	const query = `
 		SELECT


### PR DESCRIPTION
## Summary

A user of the Heimdall API can authenticate with either an API key or a session token stored within the `heimdall_sessionToken` cookie. If both are passed, the API key will be checked first, then the cookie will be checked. At least one valid method of authentication must be passed for the request to succeed.

## Testing

1. Create an API key for a client.
2. Make a request to any protected endpoint (e.g. `POST /api/v1/auth/introspect`) with the `X-API-KEY` header set to `<client id>:<api key>`. The request should not return a 401.
3. Login using the `POST /api/v1/auth/login` and ensure the returned cookie is captured. Make the same request as in step 2 and ensure the request succeeds.
4. Ensure that hitting a protected endpoint without the `X-API-KEY` header or session cookie returns a 401.

Closes #13 