### PR TITLE
Add logout endpoint

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -23,6 +23,9 @@ paths:
       summary: Returns a list of users
       operationId: getUsers
       tags: [Users]
+      security:
+        - apiKeyAuth: []
+        - sessionToken: []
       responses:
         '200':
           description: A list of users
@@ -329,6 +332,7 @@ paths:
       summary: Retrieve an access token
       operationId: authLogin
       tags: [Auth]
+      security: []
       requestBody:
           content:
             application/json:
@@ -346,7 +350,15 @@ paths:
                     example: password123!
       responses:
         '200':
-          description: Successfully logged in
+          description: >
+            Successfully authenticated.
+            The session ID is returned in a cookie named `heimdall_sessionToken`.
+            This cookie must be included in subsequent requests.
+          headers: 
+            Set-Cookie:
+              schema: 
+                type: string
+                example: heimdall_sessionToken=XdMIzEPHxFcFyVGnzpUkHLZZP0/VEftTqI/+9CaarhE=; Path=/; Max-Age=86400; HttpOnly; Secure; SameSite=Lax
           content:
             application/json:
               schema: 
@@ -369,6 +381,39 @@ paths:
                   error:
                     type: string
                     example: invalid password
+
+  /auth/logout:
+    post:
+      summary: End an existing session
+      operationId: authLogout
+      tags: [Auth]
+      security: 
+        - sessionCookie: []
+      responses:
+        '204':
+          description: >
+            Session ended.
+            The session token associated with the request will be invalidated and
+            all subsequent requests with the token will fail authentication.
+          headers: 
+            Set-Cookie:
+              schema: 
+                type: string
+                example: heimdall_sessionToken=; Path=/; Max-Age=0; HttpOnly; Secure
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    enum: [500]
+                    example: 500
+                  error:
+                    type: string
+                    example: Internal Server Error
 
   /auth/introspect:
     post:
@@ -535,3 +580,13 @@ components:
       type: string
       format: date-time
       example: 2023-01-01T00:00:00Z
+
+  securitySchemes:
+    apiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-API-KEY
+    cookieAuth:
+      type: apiKey
+      in: cookie
+      name: heimdall_sessionToken

--- a/http/routes.go
+++ b/http/routes.go
@@ -17,5 +17,6 @@ func (s *Server) loadRoutes() {
 	s.Router.With(s.authenticateRoute).Delete("/api/v1/clients/{clientID}/api-keys/{keyID}", s.handleClientsAPIKeysDelete())
 
 	s.Router.Post("/api/v1/auth/login", s.handleAuthLogin())
+	s.Router.Post("/api/v1/auth/logout", s.handleAuthLogout())
 	s.Router.With(s.authenticateRoute).Post("/api/v1/auth/introspect", s.handleAuthIntrospect())
 }

--- a/http/server.go
+++ b/http/server.go
@@ -47,6 +47,7 @@ type ClientService interface {
 
 type AuthService interface {
 	Login(ctx context.Context, username, password string) (auth.Token, error)
+	Logout(ctx context.Context, session string) error
 	IntrospectToken(ctx context.Context, token string) (auth.TokenInfo, error)
 	ValidateAPIKey(ctx context.Context, key string) error
 }

--- a/store/error.go
+++ b/store/error.go
@@ -1,0 +1,12 @@
+package store
+
+import "fmt"
+
+type NotFoundError struct {
+	ResourceType string
+	ResourceID   string
+}
+
+func (e NotFoundError) Error() string {
+	return fmt.Sprintf("%s with ID %s not found", e.ResourceType, e.ResourceID)
+}

--- a/store/session.go
+++ b/store/session.go
@@ -16,4 +16,5 @@ type Session struct {
 type SessionRepository interface {
 	GetSession(token string, opts QueryOptions) (Session, error)
 	SaveSession(session Session, opts QueryOptions) error
+	DeleteSession(token string, opts QueryOptions) error
 }

--- a/store/sqlite/session.go
+++ b/store/sqlite/session.go
@@ -54,3 +54,24 @@ func (db DB) SaveSession(session store.Session, opts store.QueryOptions) error {
 
 	return nil
 }
+
+func (db DB) DeleteSession(token string, opts store.QueryOptions) error {
+	const query = `
+        DELETE FROM
+            session
+        WHERE
+            token = ?
+    `
+
+	res, err := db.querier(opts.Txn).ExecContext(opts.Context(), query, token)
+	if err != nil {
+		return err
+	}
+
+	rows, _ := res.RowsAffected()
+	if rows == 0 {
+		return store.NotFoundError{ResourceType: "session", ResourceID: token}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR adds the `POST /api/v1/auth/logout` that ends the session linked to the session cookie.

## Testing

1. Login and ensure the session token is captured in a cookie.
2. Hit the logout endpoint and ensure the expiration `Set-Cookie` header is returned.