### PR TITLE
Add setup mode flag

### DIFF
--- a/cmd/heimdall/config.go
+++ b/cmd/heimdall/config.go
@@ -2,10 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"os"
 )
 
 type Config struct {
+	port          int
+	logLevel      string
+	runMigrations bool
+	configPath    string
+	setupMode     bool
+
 	Driver string        `json:"driver"`
 	SQLite *SQLiteConfig `json:"sqlite"`
 }
@@ -14,13 +21,37 @@ type SQLiteConfig struct {
 	Path string `json:"path"`
 }
 
-func readConfig(path string) (Config, error) {
+func loadConfig() (Config, error) {
+	config := initFlags()
+
+	return readConfig(config, config.configPath)
+}
+
+func initFlags() Config {
+	var config Config
+
+	flag.IntVar(&config.port, "port", 8080, "Port to run on.")
+	flag.BoolVar(&config.runMigrations, "migrate", false, "Run db migrations. Ignored for mem driver.")
+	flag.StringVar(&config.logLevel, "log-level", "info", "Min log level: debug, info, warn, error, fatal")
+	flag.StringVar(&config.configPath, "config", "./config.json", "Path to the config file.")
+	flag.BoolVar(
+		&config.setupMode,
+		"setup-mode",
+		false,
+		"Removes security checks. This should only be used for initial setup when the service is not exposed to the internet.",
+	)
+
+	flag.Parse()
+
+	return config
+}
+
+func readConfig(config Config, path string) (Config, error) {
 	fileContents, err := os.ReadFile(path)
 	if err != nil {
 		return Config{}, err
 	}
 
-	var config Config
 	err = json.Unmarshal(fileContents, &config)
 	if err != nil {
 		return Config{}, err

--- a/http/auth.go
+++ b/http/auth.go
@@ -13,6 +13,11 @@ var authErr = errors.New("missing or invalid auth token")
 
 func (s *Server) authenticateRoute(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if s.DisableAuth {
+			next.ServeHTTP(w, r)
+			return
+		}
+
 		err := s.authenticateAPIKey(r)
 		if err == nil {
 			next.ServeHTTP(w, r)

--- a/http/server.go
+++ b/http/server.go
@@ -20,6 +20,11 @@ type Server struct {
 	Logger level.Logger
 	Router chi.Router
 
+	// DisableAuth skips all configured auth checks on all routes. This setting
+	// is intended to be used in setup mode to allow initial users and clients
+	// to be created.
+	DisableAuth bool
+
 	UserService   UserService
 	ClientService ClientService
 	AuthService   AuthService
@@ -76,6 +81,10 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func (s *Server) ListenAndServe(addr string) error {
 	if s.Logger == nil {
 		s.Logger, _ = level.NewBasicLogger(level.Info, nil)
+	}
+
+	if s.DisableAuth {
+		s.Logger.Warn("Starting server in setup mode. All routes are unprotected.")
 	}
 
 	s.Logger.Info("Server listening on %s", addr)


### PR DESCRIPTION
## Summary

When Heimdall is first run, there will not be any users or clients. Since an authenticated user or client is required to create other users and clients, the initial resource cannot be made. This change provides a workaround by introducing the `setup-mode` flag. Currently, this flag just disables auth checks for all endpoints, but in the future it could be used for other intial setup behavior changes.

This PR also reworks the config code a little by combining the flags and config into a single struct.

## Testing

1. Start the API without the `-setup-mode` flag. Hitting any endpoints other than login/logout should result in a 401.
2. Restart the API with the `-setup-mode` flag. Try creating a user. It should should. Try hitting other endpoints. Nothing should be protected.